### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,9 @@ on:
       - '.github/workflows/tests.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Tairesh/rustormy/security/code-scanning/15](https://github.com/Tairesh/rustormy/security/code-scanning/15)

Add an explicit `permissions` block to the workflow (or this specific job) to restrict `GITHUB_TOKEN` to least privilege.  
Best single fix here: add workflow-level permissions right below `on:` section (or before `jobs:`) with `contents: read`, which is sufficient for checkout and read-only CI checks. This preserves current functionality while making permissions explicit and stable across repos/orgs.

In `.github/workflows/tests.yml`, insert:

```yml
permissions:
  contents: read
```

No imports, methods, or definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
