### PR TITLE
Add alt-screen and key bindings to live mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "directories"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +349,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -806,10 +841,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -842,6 +892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -878,6 +929,29 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1019,6 +1093,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1174,19 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustls"
@@ -1174,6 +1270,7 @@ dependencies = [
  "capitalize",
  "chrono",
  "clap",
+ "crossterm",
  "directories",
  "enum_dispatch",
  "reqwest",
@@ -1213,6 +1310,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1306,6 +1409,37 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -1798,6 +1932,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1955,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "2.0"
 directories = "6.0"
 capitalize = "0.3"
 enum_dispatch = "0.3"
+crossterm = "0.28"
 
 [dev-dependencies]
 test-case = "3"

--- a/README.md
+++ b/README.md
@@ -119,11 +119,17 @@ lon = -0.1278
 #### Live mode
 
 Live mode can be enabled with `live_mode = true` to update weather data every `live_mode_interval` seconds
-(default is 300 seconds, i.e., 5 minutes)
+(default is 300 seconds, i.e., 5 minutes). It uses the terminal's alternate screen buffer, so the original
+screen is restored on exit. While in live mode, press `q`, `Esc`, or `Ctrl+C` to quit, or `r` to force an
+immediate refresh.
+
+A footer with key hints and the last-update timestamp is shown by default. Set `live_mode_footer = false`
+(or pass `--no-footer` on the command line) to hide it.
 
 ```toml
 live_mode = false
 live_mode_interval = 300
+live_mode_footer = true
 ```
 
 ---
@@ -270,6 +276,8 @@ Options:
           Live mode - continuously update weather data every 5 minutes (or specified interval)
   -i, --interval <LIVE_MODE_INTERVAL>
           Live mode update interval in seconds (default: 300)
+      --no-footer
+          Hide the live-mode footer (key hints + last-update time)
       --no-cache
           Disable caching of geocoding results
       --clear-cache

--- a/src/app.rs
+++ b/src/app.rs
@@ -69,7 +69,7 @@ impl App {
         }
 
         match self.fetch_with_fallback() {
-            Ok(weather) => self.formatter.display(weather),
+            Ok(weather) => self.formatter.display(&weather),
             Err(error) => self.formatter.display_error(&error),
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,15 +1,11 @@
 use crate::config::{Cli, Config};
 use crate::display::formatter::WeatherFormatter;
 use crate::errors::RustormyError;
-use crate::models::Provider;
+use crate::live::run as run_live;
+use crate::models::{Provider, Weather};
 use crate::weather::{GetWeather, GetWeatherProvider};
 use reqwest::blocking::Client;
 use std::time::Duration;
-
-fn clear_screen() {
-    print!("\x1B[2J\x1B[1;1H\x1B[?25l");
-    std::io::Write::flush(&mut std::io::stdout()).ok();
-}
 
 pub struct App {
     client: Client,
@@ -35,38 +31,46 @@ impl App {
         })
     }
 
-    pub fn run(&mut self) {
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    pub fn formatter(&self) -> &WeatherFormatter {
+        &self.formatter
+    }
+
+    pub fn fetch_with_fallback(&mut self) -> Result<Weather, RustormyError> {
         loop {
             match self.provider.get_weather(&self.client, &self.config) {
-                Ok(weather) => {
-                    if self.config.live_mode() {
-                        clear_screen();
-                    }
-                    self.formatter.display(weather);
-                }
+                Ok(weather) => return Ok(weather),
                 Err(error) => match error {
                     RustormyError::ApiReturnedError(_) | RustormyError::HttpRequestFailed(_) => {
                         let p: Provider = (&self.provider).into();
                         if self.config.verbose() >= 1 {
-                            // TODO: Log this instead of printing to stderr
                             eprintln!("Provider {p:?} failed: {error:?}");
                         }
                         let Some(next) = self.config.take_next_provider() else {
-                            self.formatter.display_error(&error);
+                            return Err(error);
                         };
                         self.provider = GetWeatherProvider::new(next);
-                        continue;
                     }
-                    _ => {
-                        self.formatter.display_error(&error);
-                    }
+                    _ => return Err(error),
                 },
             }
-            if !self.config.live_mode() {
-                break;
+        }
+    }
+
+    pub fn run(&mut self) {
+        if self.config.live_mode() {
+            if let Err(error) = run_live(self) {
+                self.formatter.display_error(&error);
             }
-            let sleep_duration = Duration::from_secs(self.config.live_mode_interval());
-            std::thread::sleep(sleep_duration);
+            return;
+        }
+
+        match self.fetch_with_fallback() {
+            Ok(weather) => self.formatter.display(weather),
+            Err(error) => self.formatter.display_error(&error),
         }
     }
 }

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -75,6 +75,10 @@ pub struct Cli {
     )]
     pub live_mode_interval: Option<u64>, // in seconds, default to 300 (5 minutes)
 
+    /// Hide the live-mode footer (key hints + last-update time)
+    #[arg(long="no-footer", requires = "live_mode", action = ArgAction::SetTrue)]
+    pub no_footer: bool,
+
     /// Disable caching of geocoding results
     #[arg(long, action = ArgAction::SetTrue)]
     pub no_cache: bool,

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -75,6 +75,10 @@ pub struct Config {
     #[serde(default = "default_live_mode_interval")]
     live_mode_interval: u64, // in seconds, default to 300 (5 minutes)
 
+    /// Show key-hint footer in live mode (default: true)
+    #[serde(default = "default_live_mode_footer")]
+    live_mode_footer: bool,
+
     /// Use geocoding cache (`true` or `false`)
     /// (if enabled, previously looked up cities will be cached locally to avoid repeated API calls)
     #[serde(default)]
@@ -92,6 +96,9 @@ pub struct Config {
 fn default_live_mode_interval() -> u64 {
     300
 }
+fn default_live_mode_footer() -> bool {
+    true
+}
 fn default_connect_timeout() -> u64 {
     10
 }
@@ -107,6 +114,7 @@ impl Default for Config {
             format: FormatterConfig::default(),
             live_mode: false,
             live_mode_interval: default_live_mode_interval(),
+            live_mode_footer: default_live_mode_footer(),
             use_geocoding_cache: false,
             verbose: 0,
             connect_timeout: default_connect_timeout(),
@@ -218,6 +226,9 @@ impl Config {
         self.format.use_colors |= cli.use_colors;
         self.format.wind_in_degrees |= cli.use_degrees_for_wind;
         self.format.align_right |= cli.align_right;
+        if cli.no_footer {
+            self.live_mode_footer = false;
+        }
         self.live_mode |= cli.live_mode;
         self.use_geocoding_cache &= !cli.no_cache;
         if cli.verbose > 0 {
@@ -333,6 +344,9 @@ impl Config {
             self.live_mode_interval
         }
     }
+    pub fn live_mode_footer(&self) -> bool {
+        self.live_mode_footer
+    }
     pub fn format(&self) -> &FormatterConfig {
         &self.format
     }
@@ -427,6 +441,7 @@ impl From<LegacyConfig> for Config {
             format,
             live_mode: value.live_mode,
             live_mode_interval: value.live_mode_interval,
+            live_mode_footer: default_live_mode_footer(),
             use_geocoding_cache: value.use_geocoding_cache,
             verbose: value.verbose,
             connect_timeout: value.connect_timeout,
@@ -724,6 +739,59 @@ mod tests {
     }
 
     #[test]
+    fn test_no_footer_cli_overrides_true() {
+        let mut config = Config {
+            live_mode_footer: true,
+            ..Default::default()
+        };
+        let cli = Cli {
+            no_footer: true,
+            ..base_cli()
+        };
+        config.merge_cli(cli).unwrap();
+        assert!(!config.live_mode_footer);
+    }
+
+    #[test]
+    fn test_no_footer_absent_preserves_false() {
+        let mut config = Config {
+            live_mode_footer: false,
+            ..Default::default()
+        };
+        let cli = Cli {
+            no_footer: false,
+            ..base_cli()
+        };
+        config.merge_cli(cli).unwrap();
+        assert!(!config.live_mode_footer);
+    }
+
+    #[test]
+    fn test_live_mode_footer_default_when_missing() {
+        let toml = r#"
+providers = ["open_meteo"]
+city = "Test City"
+[api_keys]
+"#;
+        let (config, migrated) = Config::parse_config(toml).unwrap();
+        assert!(!migrated, "expected modern parse path");
+        assert!(config.live_mode_footer());
+    }
+
+    #[test]
+    fn test_live_mode_footer_explicit_false() {
+        let toml = r#"
+providers = ["open_meteo"]
+city = "Test City"
+live_mode_footer = false
+[api_keys]
+"#;
+        let (config, migrated) = Config::parse_config(toml).unwrap();
+        assert!(!migrated, "expected modern parse path");
+        assert!(!config.live_mode_footer());
+    }
+
+    #[test]
     fn test_load_incorrect_config_file() {
         let config_file_path = std::env::temp_dir().join("test_load_incorrect_config_file.toml");
         fs::write(&config_file_path, "this is not valid toml").unwrap();
@@ -785,6 +853,7 @@ mod tests {
             providers: vec![Provider::OpenMeteo],
             live_mode: false,
             live_mode_interval: 300,
+            live_mode_footer: true,
             use_geocoding_cache: true,
             verbose: 1,
             format: FormatterConfig {
@@ -816,6 +885,7 @@ mod tests {
             one_line_mode: false,
             text_mode: None,
             align_right: true,
+            no_footer: false,
             live_mode: true,
             live_mode_interval: Some(600),
             no_cache: true,
@@ -856,6 +926,7 @@ mod tests {
             one_line_mode: false,
             text_mode: None,
             align_right: false,
+            no_footer: false,
             live_mode: false,
             live_mode_interval: None,
             no_cache: false,

--- a/src/display/footer.rs
+++ b/src/display/footer.rs
@@ -1,0 +1,45 @@
+use crate::display::colored_text;
+use crate::models::AnsiColor;
+use chrono::{DateTime, Local};
+
+pub fn format_footer(timestamp: DateTime<Local>, use_colors: bool) -> String {
+    let time = timestamp.format("%H:%M:%S");
+    if use_colors {
+        let q = colored_text("[q]", AnsiColor::BrightBlack);
+        let r = colored_text("[r]", AnsiColor::BrightBlack);
+        let label = colored_text("•  last update:", AnsiColor::BrightBlack);
+        format!("{q} quit  {r} refresh  {label} {time}")
+    } else {
+        format!("[q] quit  [r] refresh  •  last update: {time}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn test_format_footer_no_color() {
+        let ts = Local
+            .with_ymd_and_hms(2026, 5, 5, 14, 32, 5)
+            .single()
+            .unwrap();
+        let footer = format_footer(ts, false);
+        assert_eq!(footer, "[q] quit  [r] refresh  •  last update: 14:32:05");
+    }
+
+    #[test]
+    fn test_format_footer_with_color_contains_ansi_escape() {
+        let ts = Local
+            .with_ymd_and_hms(2026, 5, 5, 14, 32, 5)
+            .single()
+            .unwrap();
+        let footer = format_footer(ts, true);
+        assert!(footer.contains("14:32:05"));
+        assert!(
+            footer.contains("\x1b["),
+            "expected ANSI escape in colored footer"
+        );
+    }
+}

--- a/src/display/formatter.rs
+++ b/src/display/formatter.rs
@@ -74,13 +74,13 @@ impl WeatherFormatter {
         }
     }
 
-    pub fn display(&self, weather: Weather) {
+    pub fn display(&self, weather: &Weather) {
         print!("{}", self.render_to_string(weather));
     }
 
-    pub fn render_to_string(&self, weather: Weather) -> String {
+    pub fn render_to_string(&self, weather: &Weather) -> String {
         match self.config.output_format {
-            OutputFormat::Json => self.render_json(&weather),
+            OutputFormat::Json => self.render_json(weather),
             OutputFormat::Text => self.render_text(weather),
         }
     }
@@ -95,7 +95,7 @@ impl WeatherFormatter {
         std::process::exit(1);
     }
 
-    fn render_text(&self, weather: Weather) -> String {
+    fn render_text(&self, weather: &Weather) -> String {
         if self.config.text_mode == TextMode::OneLine {
             return format!("{}\n", self.format_one_line(weather));
         }
@@ -107,7 +107,7 @@ impl WeatherFormatter {
         s
     }
 
-    fn format_one_line(&self, weather: Weather) -> String {
+    fn format_one_line(&self, weather: &Weather) -> String {
         let color_theme = &self.config.color_theme;
         let (temp_unit, wind_unit, _) = unit_strings(self.config.units, self.config.language);
         let emoji = weather.icon.emoji();
@@ -130,9 +130,9 @@ impl WeatherFormatter {
 
         if self.config.show_city_name {
             let location = if self.config.use_colors {
-                colored_text(weather.location_name, color_theme.location)
+                colored_text(&weather.location_name, color_theme.location)
             } else {
-                weather.location_name
+                weather.location_name.clone()
             };
             format!("{location}: {value}")
         } else {
@@ -140,7 +140,7 @@ impl WeatherFormatter {
         }
     }
 
-    fn format_text(&self, weather: Weather) -> Vec<String> {
+    fn format_text(&self, weather: &Weather) -> Vec<String> {
         let (compact, colors, name, lang) = (
             self.config.text_mode == TextMode::Compact,
             self.config.use_colors,
@@ -161,7 +161,7 @@ impl WeatherFormatter {
             output.push(make_line(
                 icon[0],
                 "Location",
-                weather.location_name,
+                &weather.location_name,
                 color_theme.location,
                 &self.config,
             ));
@@ -175,7 +175,7 @@ impl WeatherFormatter {
             if let Some(uv) = weather.uv_index {
                 format!("{} ({} {uv:.1})", weather.description, ll(lang, "UV index"))
             } else {
-                weather.description
+                weather.description.clone()
             },
             condition_color(weather.icon),
             &self.config,
@@ -273,7 +273,7 @@ mod tests {
     #[test]
     fn test_render_to_string_full_text_has_seven_lines() {
         let formatter = WeatherFormatter::new(&Config::default());
-        let s = formatter.render_to_string(sample_weather());
+        let s = formatter.render_to_string(&sample_weather());
         let line_count = s.lines().count();
         assert_eq!(line_count, 7, "rendered text:\n{s}");
         assert!(
@@ -289,7 +289,7 @@ mod tests {
         format.text_mode = TextMode::OneLine;
         config.set_format(format);
         let formatter = WeatherFormatter::new(&config);
-        let s = formatter.render_to_string(sample_weather());
+        let s = formatter.render_to_string(&sample_weather());
         assert_eq!(s.lines().count(), 1, "rendered text:\n{s}");
         assert!(s.ends_with('\n'));
     }
@@ -299,7 +299,7 @@ mod tests {
         let weather = sample_weather();
         let config = Config::default();
         let formatter = WeatherFormatter::new(&config);
-        let lines = formatter.format_text(weather);
+        let lines = formatter.format_text(&weather);
 
         assert_eq!(lines.len(), 7);
         assert_eq!(
@@ -399,7 +399,7 @@ mod tests {
             ..Default::default()
         });
         let formatter = WeatherFormatter::new(&config);
-        let lines = formatter.format_text(weather);
+        let lines = formatter.format_text(&weather);
 
         assert_eq!(lines.len(), 6);
         assert!(
@@ -495,7 +495,7 @@ mod tests {
         weather.uv_index = Some(7.2);
         let config = Config::default();
         let formatter = WeatherFormatter::new(&config);
-        let lines = formatter.format_text(weather);
+        let lines = formatter.format_text(&weather);
 
         assert_eq!(lines.len(), 7);
         assert!(
@@ -514,7 +514,7 @@ mod tests {
             ..Default::default()
         });
         let formatter = WeatherFormatter::new(&config);
-        let lines = formatter.format_text(weather);
+        let lines = formatter.format_text(&weather);
 
         assert_eq!(lines.len(), 7);
         assert!(
@@ -538,7 +538,7 @@ mod tests {
             ..Default::default()
         });
         let formatter = WeatherFormatter::new(&config);
-        let lines = formatter.format_text(weather);
+        let lines = formatter.format_text(&weather);
 
         assert_eq!(lines.len(), 7);
         // Check colors in every line except the first and the last one
@@ -559,7 +559,7 @@ mod tests {
             ..Default::default()
         });
         let formatter = WeatherFormatter::new(&config);
-        let lines = formatter.format_text(weather);
+        let lines = formatter.format_text(&weather);
 
         assert_eq!(lines.len(), 7);
         assert!(
@@ -588,7 +588,7 @@ mod tests {
             ..Default::default()
         });
         let formatter = WeatherFormatter::new(&config);
-        let lines = formatter.format_text(weather);
+        let lines = formatter.format_text(&weather);
 
         assert_eq!(lines.len(), 7);
         assert!(
@@ -627,7 +627,7 @@ mod tests {
                 ..Default::default()
             });
             let formatter = WeatherFormatter::new(&config);
-            let lines = formatter.format_text(weather);
+            let lines = formatter.format_text(&weather);
 
             assert_eq!(lines.len(), 7);
             assert!(
@@ -653,7 +653,7 @@ mod tests {
             ..Default::default()
         });
         let formatter = WeatherFormatter::new(&config);
-        let lines = formatter.format_text(weather);
+        let lines = formatter.format_text(&weather);
 
         assert_eq!(lines.len(), 7);
         assert!(
@@ -673,7 +673,7 @@ mod tests {
             ..Default::default()
         });
         let formatter = WeatherFormatter::new(&config);
-        let line = formatter.format_one_line(weather);
+        let line = formatter.format_one_line(&weather);
 
         assert!(
             line.contains("Test City"),
@@ -702,7 +702,7 @@ mod tests {
             ..Default::default()
         });
         let formatter = WeatherFormatter::new(&config);
-        let line = formatter.format_one_line(weather);
+        let line = formatter.format_one_line(&weather);
 
         assert!(
             !line.contains("Test City"),
@@ -727,7 +727,7 @@ mod tests {
             ..Default::default()
         });
         let formatter = WeatherFormatter::new(&config);
-        let lines = formatter.format_text(weather);
+        let lines = formatter.format_text(&weather);
 
         // Check if there are no extra spaces between the label and the value
         assert!(
@@ -753,7 +753,7 @@ mod tests {
         weather.uv_index = Some(5.);
         let config = Config::default();
         let formatter = WeatherFormatter::new(&config);
-        let lines = formatter.format_text(weather);
+        let lines = formatter.format_text(&weather);
 
         assert_eq!(lines.len(), 7);
         assert!(

--- a/src/display/formatter.rs
+++ b/src/display/formatter.rs
@@ -75,9 +75,13 @@ impl WeatherFormatter {
     }
 
     pub fn display(&self, weather: Weather) {
+        print!("{}", self.render_to_string(weather));
+    }
+
+    pub fn render_to_string(&self, weather: Weather) -> String {
         match self.config.output_format {
-            OutputFormat::Json => self.display_json(&weather),
-            OutputFormat::Text => self.display_text(weather),
+            OutputFormat::Json => self.render_json(&weather),
+            OutputFormat::Text => self.render_text(weather),
         }
     }
 
@@ -91,15 +95,16 @@ impl WeatherFormatter {
         std::process::exit(1);
     }
 
-    fn display_text(&self, weather: Weather) {
+    fn render_text(&self, weather: Weather) -> String {
         if self.config.text_mode == TextMode::OneLine {
-            println!("{}", self.format_one_line(weather));
-            return;
+            return format!("{}\n", self.format_one_line(weather));
         }
-
-        self.format_text(weather)
-            .iter()
-            .for_each(|line| println!("{line}"));
+        let mut s = String::new();
+        for line in self.format_text(weather) {
+            s.push_str(&line);
+            s.push('\n');
+        }
+        s
     }
 
     fn format_one_line(&self, weather: Weather) -> String {
@@ -234,11 +239,11 @@ impl WeatherFormatter {
         output
     }
 
-    fn display_json(&self, weather: &Weather) {
+    fn render_json(&self, weather: &Weather) -> String {
         let json = serde_json::to_string_pretty(weather).unwrap_or_else(|e| {
             self.display_error(&RustormyError::JsonSerializeError(e));
         });
-        println!("{json}");
+        format!("{json}\n")
     }
 }
 
@@ -263,6 +268,30 @@ mod tests {
             icon: WeatherConditionIcon::PartlyCloudy,
             location_name: "Test City".to_string(),
         }
+    }
+
+    #[test]
+    fn test_render_to_string_full_text_has_seven_lines() {
+        let formatter = WeatherFormatter::new(&Config::default());
+        let s = formatter.render_to_string(sample_weather());
+        let line_count = s.lines().count();
+        assert_eq!(line_count, 7, "rendered text:\n{s}");
+        assert!(
+            s.ends_with('\n'),
+            "render_to_string output must end with newline"
+        );
+    }
+
+    #[test]
+    fn test_render_to_string_one_line() {
+        let mut config = Config::default();
+        let mut format = config.format().clone();
+        format.text_mode = TextMode::OneLine;
+        config.set_format(format);
+        let formatter = WeatherFormatter::new(&config);
+        let s = formatter.render_to_string(sample_weather());
+        assert_eq!(s.lines().count(), 1, "rendered text:\n{s}");
+        assert!(s.ends_with('\n'));
     }
 
     #[test]

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -1,5 +1,8 @@
 mod color;
+pub mod footer;
 pub mod formatter;
 pub mod icons;
 mod theme;
 pub mod translations;
+
+pub use color::colored_text;

--- a/src/live.rs
+++ b/src/live.rs
@@ -1,0 +1,153 @@
+use crate::app::App;
+use crate::display::footer::format_footer;
+use crate::display::formatter::WeatherFormatter;
+use crate::errors::RustormyError;
+use crate::models::Weather;
+use chrono::{DateTime, Local};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::{cursor, execute, terminal};
+use std::io::{self, Write};
+use std::time::{Duration, Instant};
+
+fn write_payload<W: Write>(writer: &mut W, text: &str) -> io::Result<()> {
+    for line in text.split_inclusive('\n') {
+        if let Some(stripped) = line.strip_suffix('\n') {
+            writer.write_all(stripped.as_bytes())?;
+            writer.write_all(b"\r\n")?;
+        } else {
+            writer.write_all(line.as_bytes())?;
+        }
+    }
+    Ok(())
+}
+
+pub struct TerminalGuard;
+
+impl TerminalGuard {
+    pub fn enter() -> io::Result<Self> {
+        terminal::enable_raw_mode()?;
+        if let Err(e) = execute!(io::stdout(), terminal::EnterAlternateScreen, cursor::Hide) {
+            let _ = terminal::disable_raw_mode();
+            return Err(e);
+        }
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = execute!(io::stdout(), cursor::Show, terminal::LeaveAlternateScreen);
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
+pub fn render(
+    stdout: &mut io::Stdout,
+    formatter: &WeatherFormatter,
+    weather: Weather,
+    timestamp: DateTime<Local>,
+    show_footer: bool,
+    use_colors: bool,
+) -> io::Result<()> {
+    execute!(
+        stdout,
+        terminal::Clear(terminal::ClearType::All),
+        cursor::MoveTo(0, 0),
+    )?;
+    let body = formatter.render_to_string(weather);
+    write_payload(stdout, &body)?;
+    if show_footer {
+        let footer = format_footer(timestamp, use_colors);
+        stdout.write_all(footer.as_bytes())?;
+        stdout.write_all(b"\r\n")?;
+    }
+    stdout.flush()?;
+    Ok(())
+}
+
+pub fn run(app: &mut App) -> Result<(), RustormyError> {
+    // First fetch runs before entering the alt screen so the user's
+    // existing terminal contents stay visible during the initial API call.
+    let mut weather = app.fetch_with_fallback()?;
+    let mut now = Local::now();
+
+    let _guard = TerminalGuard::enter()?;
+    let mut stdout = io::stdout();
+
+    loop {
+        let show_footer = app.config().live_mode_footer();
+        let use_colors = app.config().format().use_colors;
+        render(
+            &mut stdout,
+            app.formatter(),
+            weather,
+            now,
+            show_footer,
+            use_colors,
+        )?;
+
+        let interval = Duration::from_secs(app.config().live_mode_interval());
+        let deadline = Instant::now() + interval;
+
+        loop {
+            let remaining_wait = deadline.saturating_duration_since(Instant::now());
+            if remaining_wait.is_zero() {
+                break;
+            }
+            if event::poll(remaining_wait)?
+                && let Event::Key(KeyEvent {
+                    code,
+                    modifiers,
+                    kind: KeyEventKind::Press,
+                    ..
+                }) = event::read()?
+            {
+                match (code, modifiers) {
+                    (KeyCode::Char('q') | KeyCode::Esc, _)
+                    | (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(()),
+                    (KeyCode::Char('r'), _) => break,
+                    _ => {}
+                }
+            }
+        }
+
+        weather = app.fetch_with_fallback()?;
+        now = Local::now();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn capture(text: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        write_payload(&mut buf, text).unwrap();
+        buf
+    }
+
+    #[test]
+    fn test_write_payload_empty() {
+        assert_eq!(capture(""), b"");
+    }
+
+    #[test]
+    fn test_write_payload_single_line_no_newline() {
+        assert_eq!(capture("hello"), b"hello");
+    }
+
+    #[test]
+    fn test_write_payload_single_line_with_newline() {
+        assert_eq!(capture("hello\n"), b"hello\r\n");
+    }
+
+    #[test]
+    fn test_write_payload_multi_line() {
+        assert_eq!(capture("a\nb\nc\n"), b"a\r\nb\r\nc\r\n");
+    }
+
+    #[test]
+    fn test_write_payload_no_trailing_newline_in_multiline() {
+        assert_eq!(capture("a\nb\nc"), b"a\r\nb\r\nc");
+    }
+}

--- a/src/live.rs
+++ b/src/live.rs
@@ -44,7 +44,7 @@ impl Drop for TerminalGuard {
 pub fn render(
     stdout: &mut io::Stdout,
     formatter: &WeatherFormatter,
-    weather: Weather,
+    weather: &Weather,
     timestamp: DateTime<Local>,
     show_footer: bool,
     use_colors: bool,
@@ -80,7 +80,7 @@ pub fn run(app: &mut App) -> Result<(), RustormyError> {
         render(
             &mut stdout,
             app.formatter(),
-            weather,
+            &weather,
             now,
             show_footer,
             use_colors,
@@ -94,18 +94,29 @@ pub fn run(app: &mut App) -> Result<(), RustormyError> {
             if remaining_wait.is_zero() {
                 break;
             }
-            if event::poll(remaining_wait)?
-                && let Event::Key(KeyEvent {
-                    code,
-                    modifiers,
-                    kind: KeyEventKind::Press,
-                    ..
-                }) = event::read()?
-            {
-                match (code, modifiers) {
-                    (KeyCode::Char('q') | KeyCode::Esc, _)
-                    | (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(()),
-                    (KeyCode::Char('r'), _) => break,
+            if event::poll(remaining_wait)? {
+                match event::read()? {
+                    Event::Key(KeyEvent {
+                        code,
+                        modifiers,
+                        kind: KeyEventKind::Press,
+                        ..
+                    }) => match (code, modifiers) {
+                        (KeyCode::Char('q') | KeyCode::Esc, _)
+                        | (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(()),
+                        (KeyCode::Char('r'), _) => break,
+                        _ => {}
+                    },
+                    Event::Resize(_, _) => {
+                        render(
+                            &mut stdout,
+                            app.formatter(),
+                            &weather,
+                            now,
+                            show_footer,
+                            use_colors,
+                        )?;
+                    }
                     _ => {}
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod cache;
 mod config;
 mod display;
 mod errors;
+mod live;
 mod models;
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary

Live mode now uses the terminal's alternate screen buffer with non-blocking key handling, so the user's existing terminal contents are preserved and they can quit or refresh interactively.

- **Alt screen**: enters via `crossterm` on first successful fetch, restored on exit (clean exit, `Ctrl+C`, error path, panic) by a `TerminalGuard` RAII type.
- **Keys**: `q` / `Esc` / `Ctrl+C` quit immediately; `r` forces an immediate refresh.
- **Footer**: optional one-line footer with key hints + last-update timestamp (`[q] quit  [r] refresh  •  last update: HH:MM:SS`). Configurable via `live_mode_footer = true|false` in TOML and `--no-footer` on the CLI.
- **First fetch outside alt screen**: keeps the user's normal terminal visible while the initial API call loads instead of showing a blank alt screen.
- **Provider-fallback refactor**: `App::fetch_with_fallback` is now a method, used by both one-shot and live paths. The live path can now return `Result` so `TerminalGuard` runs before any error exit (previously `display_error` called `process::exit`, skipping destructors).

## Test plan

- [x] `just check` passes — 104 tests, clippy `-D pedantic` clean
- [x] New regression tests for `live_mode_footer` config field (defaults, explicit `false`, CLI override, CLI absent preserves config value)
- [x] New tests for `format_footer` (color on/off) and `write_payload` (CRLF translation, 5 edge cases)
- [x] New tests for `WeatherFormatter::render_to_string` (full text + one-line modes)
- [x] Manual smoke test on Linux: `cargo run -- -c "<city>" --live -i 10` — verify alt-screen restore, key bindings, footer
- [x] Manual smoke test with `--no-footer`
- [ ] Manual smoke test on macOS / Windows (nice-to-have)

## Notes

- Adds a single dependency: `crossterm = "0.28"` (cross-platform alt-screen + raw mode + key events; no separate `ctrlc` crate needed since `Ctrl+C` arrives as a regular `KeyEvent` in raw mode).
- One-shot path (`rustormy -c <city>`) is byte-for-byte identical to before — only the live path changed.
- `\n → \r\n` translation is required because raw mode disables the kernel's `ONLCR` line-discipline; verified to behave the same on Linux, macOS, and Windows console.